### PR TITLE
#6 - Update spring security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 	<parent>
 		<groupId>de.dataelementhub</groupId>
 		<artifactId>parent-spring</artifactId>
-		<version>10.2.0</version>
+		<version>11.0.0</version>
 	</parent>
 	<artifactId>dehub-rest</artifactId>
 	<version>1.0.1</version>
 	<name>DataElementHub REST Application</name>
 
   <properties>
-    <spring.security.version>5.2.10.RELEASE</spring.security.version>
+    <spring.security.version>5.5.2</spring.security.version>
   </properties>
 
 	<dependencies>
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.10.3</version>
+			<version>2.13.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>de.dataelementhub</groupId>
 			<artifactId>dehub-model</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.2.19</version>
+			<version>42.2.24.jre7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -157,7 +157,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-ui</artifactId>
-			<version>1.5.7</version>
+			<version>1.5.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jooq</groupId>

--- a/src/main/java/de/dataelementhub/rest/DataElementHubRestApplication.java
+++ b/src/main/java/de/dataelementhub/rest/DataElementHubRestApplication.java
@@ -9,13 +9,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {R2dbcAutoConfiguration.class})
 public class DataElementHubRestApplication {
 
   @Value("${spring.datasource.url}")

--- a/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
@@ -258,7 +258,7 @@ public class NamespaceController {
       return new ResponseEntity<>(HttpStatus.NOT_ACCEPTABLE);
     } catch (NoSuchMethodException e) {
       return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
-    } catch (IOException e) {
+    } catch (IOException | IllegalStateException e) {
       return new ResponseEntity<>(e.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
     }
   }


### PR DESCRIPTION
**What's in the PR**
* update parent pom to 11.0.0 (includes update to spring 2.5.5)
* update spring security to 5.5.2
* update postgresql, jackson-annotations, springdoc-openapi-ui and dehub-model
* catch illegal state exception when updating namespaces

**How to test manually**
* no changes in functinality expected. So everything should work like it did before
