### PR TITLE
#15 - Namespace admin can invite users and manage access scopes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>de.dataelementhub</groupId>
 			<artifactId>dehub-dal</artifactId>
-			<version>1.0.0</version>
+			<version>2.0.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>de.dataelementhub</groupId>
 			<artifactId>dehub-model</artifactId>
-			<version>1.3.0-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/de/dataelementhub/rest/controller/v1/ExportController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/ExportController.java
@@ -91,7 +91,7 @@ public class ExportController {
   /**
    * Returns export file if done otherwise returns export status.
    */
-  @GetMapping(produces={"application/zip", "text/plain"}, value = "/export/{exportId}")
+  @GetMapping(produces = {"application/zip", "text/plain"}, value = "/export/{exportId}")
   @Order(SecurityProperties.BASIC_AUTH_ORDER)
   public ResponseEntity exportStatus(
       @PathVariable(value = "exportId") String exportId,

--- a/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
@@ -1,6 +1,6 @@
 package de.dataelementhub.rest.controller.v1;
 
-import de.dataelementhub.dal.jooq.enums.GrantType;
+import de.dataelementhub.dal.jooq.enums.AccessLevelType;
 import de.dataelementhub.dal.jooq.enums.Status;
 import de.dataelementhub.dal.jooq.tables.pojos.ScopedIdentifier;
 import de.dataelementhub.model.Deserializer;
@@ -79,16 +79,16 @@ public class NamespaceController {
       @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String responseType,
       @RequestParam(name = "scope", required = false) String scope) {
 
-    Map<GrantType, List<Namespace>> namespaceMap;
+    Map<AccessLevelType, List<Namespace>> namespaceMap;
 
     if (scope == null) {
       namespaceMap = elementService
           .readNamespaces(DataElementHubRestApplication.getCurrentUser().getId());
     } else {
       try {
-        GrantType scopeGrantType = GrantType.valueOf(scope.toUpperCase());
+        AccessLevelType scopeAccessLevel = AccessLevelType.valueOf(scope.toUpperCase());
         namespaceMap = elementService
-            .readNamespaces(DataElementHubRestApplication.getCurrentUser().getId(), scopeGrantType);
+            .readNamespaces(DataElementHubRestApplication.getCurrentUser().getId(), scopeAccessLevel);
       } catch (IllegalAccessException e) {
         return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
       } catch (IllegalArgumentException e) {
@@ -101,7 +101,7 @@ public class NamespaceController {
     }
     if (responseType != null && responseType
         .equalsIgnoreCase(MediaType.JSON_LIST_VIEW.getLiteral())) {
-      Map<GrantType, List<de.dataelementhub.model.dto.listviews.Namespace>> namespaceListViewMap
+      Map<AccessLevelType, List<de.dataelementhub.model.dto.listviews.Namespace>> namespaceListViewMap
           = new HashMap<>();
       namespaceMap.entrySet().stream()
           .forEach(es -> {

--- a/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
@@ -320,7 +320,8 @@ public class NamespaceController {
    * Read user access to namespace by namespace identifier.
    */
   @GetMapping("/{namespaceIdentifier}/access")
-  public ResponseEntity readAccessGrants(
+  @Order(SecurityProperties.BASIC_AUTH_ORDER)
+  public ResponseEntity readAccessLevels(
       @PathVariable(value = "namespaceIdentifier") String namespaceIdentifier) {
     if (DataElementHubRestApplication.getCurrentUser().getId() < 0) {
       return new ResponseEntity(HttpStatus.UNAUTHORIZED);
@@ -343,8 +344,9 @@ public class NamespaceController {
   /**
    * Update user access to namespace.
    */
-  @PutMapping("/{namespaceIdentifier}/access")
-  public ResponseEntity changeAccessGrants(
+  @PatchMapping("/{namespaceIdentifier}/access")
+  @Order(SecurityProperties.BASIC_AUTH_ORDER)
+  public ResponseEntity changeAccessLevels(
       @PathVariable(value = "namespaceIdentifier") String namespaceIdentifier,
       @RequestBody List<DeHubUserPermission> permissions) {
 
@@ -358,6 +360,8 @@ public class NamespaceController {
       return new ResponseEntity(HttpStatus.FORBIDDEN);
     } catch (NoSuchElementException nse) {
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    } catch (IllegalArgumentException e) {
+      return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
   }
 
@@ -365,7 +369,8 @@ public class NamespaceController {
    * Remove user access from namespace.
    */
   @DeleteMapping("/{namespaceIdentifier}/access/{userAuthId}")
-  public ResponseEntity changeAccessGrants(
+  @Order(SecurityProperties.BASIC_AUTH_ORDER)
+  public ResponseEntity deleteAccessLevels(
       @PathVariable(value = "namespaceIdentifier") String namespaceIdentifier,
       @PathVariable(value = "userAuthId") String userAuthId) {
 

--- a/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
@@ -49,6 +49,9 @@ public class NamespaceController {
   private UserService userService;
   private JsonValidationService jsonValidationService;
 
+  /**
+   * Create a new NamespaceController.
+   */
   @Autowired
   public NamespaceController(ElementService elementService, UserService userService,
       JsonValidationService jsonValidationService) {
@@ -88,7 +91,8 @@ public class NamespaceController {
       try {
         AccessLevelType scopeAccessLevel = AccessLevelType.valueOf(scope.toUpperCase());
         namespaceMap = elementService
-            .readNamespaces(DataElementHubRestApplication.getCurrentUser().getId(), scopeAccessLevel);
+            .readNamespaces(DataElementHubRestApplication.getCurrentUser().getId(),
+                scopeAccessLevel);
       } catch (IllegalAccessException e) {
         return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
       } catch (IllegalArgumentException e) {
@@ -101,8 +105,8 @@ public class NamespaceController {
     }
     if (responseType != null && responseType
         .equalsIgnoreCase(MediaType.JSON_LIST_VIEW.getLiteral())) {
-      Map<AccessLevelType, List<de.dataelementhub.model.dto.listviews.Namespace>> namespaceListViewMap
-          = new HashMap<>();
+      Map<AccessLevelType, List<de.dataelementhub.model.dto.listviews.Namespace>>
+          namespaceListViewMap = new HashMap<>();
       namespaceMap.entrySet().stream()
           .forEach(es -> {
             List<de.dataelementhub.model.dto.listviews.Namespace> nsviews = new ArrayList<>();
@@ -312,9 +316,15 @@ public class NamespaceController {
     }
   }
 
+  /**
+   * Read user access to namespace by namespace identifier.
+   */
   @GetMapping("/{namespaceIdentifier}/access")
   public ResponseEntity readAccessGrants(
       @PathVariable(value = "namespaceIdentifier") String namespaceIdentifier) {
+    if (DataElementHubRestApplication.getCurrentUser().getId() < 0) {
+      return new ResponseEntity(HttpStatus.UNAUTHORIZED);
+    }
     try {
       elementService
           .read(DataElementHubRestApplication.getCurrentUser().getId(), namespaceIdentifier);
@@ -330,6 +340,9 @@ public class NamespaceController {
     }
   }
 
+  /**
+   * Update user access to namespace.
+   */
   @PutMapping("/{namespaceIdentifier}/access")
   public ResponseEntity changeAccessGrants(
       @PathVariable(value = "namespaceIdentifier") String namespaceIdentifier,

--- a/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
@@ -361,4 +361,25 @@ public class NamespaceController {
     }
   }
 
+  /**
+   * Remove user access from namespace.
+   */
+  @DeleteMapping("/{namespaceIdentifier}/access/{userAuthId}")
+  public ResponseEntity changeAccessGrants(
+      @PathVariable(value = "namespaceIdentifier") String namespaceIdentifier,
+      @PathVariable(value = "userAuthId") String userAuthId) {
+
+    try {
+      elementService
+          .read(DataElementHubRestApplication.getCurrentUser().getId(), namespaceIdentifier);
+      userService.revokeAccessToNamespace(DataElementHubRestApplication.getCurrentUser().getId(),
+          Integer.parseInt(namespaceIdentifier), userAuthId);
+      return new ResponseEntity(HttpStatus.NO_CONTENT);
+    } catch (IllegalAccessException e) {
+      return new ResponseEntity(HttpStatus.FORBIDDEN);
+    } catch (NoSuchElementException nse) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+  }
+
 }

--- a/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/NamespaceController.java
@@ -379,11 +379,13 @@ public class NamespaceController {
           .read(DataElementHubRestApplication.getCurrentUser().getId(), namespaceIdentifier);
       userService.revokeAccessToNamespace(DataElementHubRestApplication.getCurrentUser().getId(),
           Integer.parseInt(namespaceIdentifier), userAuthId);
-      return new ResponseEntity(HttpStatus.NO_CONTENT);
+      return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     } catch (IllegalAccessException e) {
-      return new ResponseEntity(HttpStatus.FORBIDDEN);
+      return new ResponseEntity<>(HttpStatus.FORBIDDEN);
     } catch (NoSuchElementException nse) {
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    } catch (IllegalArgumentException e) {
+      return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
   }
 


### PR DESCRIPTION
**What's in the PR**
* add /namespace/id/access endpoint to GET and PUT access grants for users

**How to test manually**
* get [dehub.model pr #14](https://github.com/mig-frankfurt/dataelementhub.model/pull/14)
* GET /namespaces/{namespaceidentifier}/access should give you a list of all users with explicit access to this namespace. ~~Currently, everyone can read this. To be discussed if this shall be limited to only namespace admins.~~
* PATCH /namespaces/1/access with a json array of permissions (see below for example) to update the corresponding user access levels. To do this, you need admin access to the namespace. User auth id is the keycloak id. ~~Users currently not known will be created in the db (currently without username or email...this should probably get changed or just throw an error?)~~ Trying to add users that are not yet known in the database will have the entire request failing.

```json
[
  {
    "userAuthId": "foo-bar",
    "accessLevel": "WRITE"
  }, {
    "userAuthId": "bar-foo",
    "accessLevel": "READ"
  }
]
```
* DELETE /namespaces/1/access/userauthid to remove a users access to the namespace