### PR TITLE
#26 - Update dataElementGroup members

### DIFF
--- a/src/main/java/de/dataelementhub/rest/DataElementHubRestApplication.java
+++ b/src/main/java/de/dataelementhub/rest/DataElementHubRestApplication.java
@@ -28,8 +28,6 @@ public class DataElementHubRestApplication {
   @Value("${spring.datasource.password}")
   private String password;
 
-  public static final String restVersion = "v1";
-
   /**
    * Start the rest application.
    */

--- a/src/main/java/de/dataelementhub/rest/DataElementHubRestApplication.java
+++ b/src/main/java/de/dataelementhub/rest/DataElementHubRestApplication.java
@@ -28,6 +28,8 @@ public class DataElementHubRestApplication {
   @Value("${spring.datasource.password}")
   private String password;
 
+  public static final String restVersion = "v1";
+
   /**
    * Start the rest application.
    */

--- a/src/main/java/de/dataelementhub/rest/controller/v1/ApiVersion.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/ApiVersion.java
@@ -1,0 +1,5 @@
+package de.dataelementhub.rest.controller.v1;
+
+public class ApiVersion {
+  public static final String API_VERSION = "v1";
+}

--- a/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
@@ -1,6 +1,6 @@
 package de.dataelementhub.rest.controller.v1;
 
-import static de.dataelementhub.rest.DataElementHubRestApplication.restVersion;
+import static de.dataelementhub.rest.controller.v1.ApiVersion.API_VERSION;
 
 import de.dataelementhub.dal.ResourceManager;
 import de.dataelementhub.dal.jooq.enums.Status;
@@ -21,8 +21,6 @@ import de.dataelementhub.model.service.ElementService;
 import de.dataelementhub.model.service.JsonValidationService;
 import de.dataelementhub.rest.DataElementHubRestApplication;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -47,13 +45,13 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
-@RequestMapping("/" + restVersion + "/element")
+@RequestMapping("/" + API_VERSION + "/element")
 public class ElementController {
 
   private ElementService elementService;
   private JsonValidationService jsonValidationService;
 
-  private static final String elementPath = "/" + restVersion + "/element/{urn}";
+  private static final String elementPath = "/" + API_VERSION + "/element/{urn}";
 
   @Autowired
   public ElementController(ElementService elementService,

--- a/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
@@ -1,5 +1,7 @@
 package de.dataelementhub.rest.controller.v1;
 
+import static de.dataelementhub.rest.DataElementHubRestApplication.restVersion;
+
 import de.dataelementhub.dal.ResourceManager;
 import de.dataelementhub.dal.jooq.enums.Status;
 import de.dataelementhub.dal.jooq.tables.pojos.ScopedIdentifier;
@@ -45,11 +47,13 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
-@RequestMapping("/v1/element")
+@RequestMapping("/" + restVersion + "/element")
 public class ElementController {
 
   private ElementService elementService;
   private JsonValidationService jsonValidationService;
+
+  private static final String elementPath = "/" + restVersion + "/element/{urn}";
 
   @Autowired
   public ElementController(ElementService elementService,
@@ -358,9 +362,10 @@ public class ElementController {
 
   /**
    * Update dataElementGroup or record members.
-   * If changes acquired return the new location otherwise return the old one.
+   * If at least one member has new version return the new element location
+   * otherwise return the old one.
    */
-  @PutMapping("/{urn}/members")
+  @PostMapping("/{urn}/updateMembers")
   @Order(SecurityProperties.BASIC_AUTH_ORDER)
   public ResponseEntity updateMembers(@PathVariable(value = "urn") String urn,
       UriComponentsBuilder uriComponentsBuilder) {
@@ -369,7 +374,7 @@ public class ElementController {
           DataElementHubRestApplication.getCurrentUser().getId(), urn);
       UriComponents uriComponents;
       uriComponents =
-          uriComponentsBuilder.path("/v1/element/{urn}").buildAndExpand(newUrn);
+          uriComponentsBuilder.path(elementPath).buildAndExpand(newUrn);
       HttpHeaders httpHeaders = new HttpHeaders();
       httpHeaders.setLocation(uriComponents.toUri());
       return new ResponseEntity<>(httpHeaders, HttpStatus.OK);

--- a/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
@@ -355,4 +355,30 @@ public class ElementController {
       return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
   }
+
+  /**
+   * Update dataElementGroup or record members.
+   * If changes acquired return the new location otherwise return the old one.
+   */
+  @PutMapping("/{urn}/members")
+  @Order(SecurityProperties.BASIC_AUTH_ORDER)
+  public ResponseEntity updateMembers(@PathVariable(value = "urn") String urn,
+      UriComponentsBuilder uriComponentsBuilder) {
+    try {
+      String newUrn = elementService.updateMembers(
+          DataElementHubRestApplication.getCurrentUser().getId(), urn);
+      UriComponents uriComponents;
+      uriComponents =
+          uriComponentsBuilder.path("/v1/element/{urn}").buildAndExpand(newUrn);
+      HttpHeaders httpHeaders = new HttpHeaders();
+      httpHeaders.setLocation(uriComponents.toUri());
+      return new ResponseEntity<>(httpHeaders, HttpStatus.OK);
+    } catch (NoSuchElementException nse) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    } catch (IllegalAccessException e) {
+      return new ResponseEntity<>(e, HttpStatus.FORBIDDEN);
+    } catch (IllegalArgumentException e) {
+      return new ResponseEntity<>(e, HttpStatus.BAD_REQUEST);
+    }
+  }
 }

--- a/src/main/resources/static/api-docs.json
+++ b/src/main/resources/static/api-docs.json
@@ -488,8 +488,8 @@
         ]
       }
     },
-    "/v1/element/{urn}/members": {
-      "put": {
+    "/v1/element/{urn}/updateMembers": {
+      "post": {
         "tags": [
           "Element"
         ],
@@ -537,7 +537,7 @@
             }
           },
           "400": {
-            "description": "Element Type is not supported. Only dataELementGroup and record are accepted!",
+            "description": "Element Type is not supported. Only dataElementGroup and record are accepted!",
             "content": {
               "*/*": {
                 "schema": {

--- a/src/main/resources/static/api-docs.json
+++ b/src/main/resources/static/api-docs.json
@@ -488,6 +488,75 @@
         ]
       }
     },
+    "/v1/element/{urn}/members": {
+      "put": {
+        "tags": [
+          "Element"
+        ],
+        "summary": "Update dataElementGroup or record members by urn.",
+        "operationId": "Update dataElementGroup or record members by urn.",
+        "parameters": [
+          {
+            "name": "urn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Element not Found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "User has no write access to namespace",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Element Type is not supported. Only dataELementGroup and record are accepted!",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth2": []
+          },
+          {
+            "basicAuth": []
+          }
+        ]
+      }
+    },
     "/v1/element/{urn}": {
       "get": {
         "tags": [


### PR DESCRIPTION
**What's in the PR**
* Add endpoint to enable updating dataElementGroup or record members by urn.

**How to test manually**
* Check if using this endpoint lead to replace dataElementGroup and record members with the newest versions. (+ [MODEL PR](https://github.com/mig-frankfurt/dataelementhub.model/pull/18))
