### PR TITLE
#31 - Change response when creating an export

### DIFF
--- a/src/main/java/de/dataelementhub/rest/controller/v1/ExportController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/ExportController.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -34,6 +35,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequestMapping("/v1")
@@ -72,7 +75,7 @@ public class ExportController {
   public ResponseEntity<String> export(@RequestBody ExportRequest exportRequest,
       @RequestParam(value = "format", required = false, defaultValue = "JSON") String format,
       @RequestParam(value = "fullExport", required = false,
-          defaultValue = "true") Boolean fullExport) {
+          defaultValue = "true") Boolean fullExport, UriComponentsBuilder uriComponentsBuilder) {
     int numberOfNamespacesExportedFrom = exportRequest.getElementUrns().stream()
         .map(e -> e.split(":")[1]).collect(Collectors.toSet()).size();
     if (numberOfNamespacesExportedFrom > 1) {
@@ -84,7 +87,11 @@ public class ExportController {
         .toString().replaceAll("[ \\.\\-\\:]", "_");
     exportService
         .exportService(exportRequest, userId, format, fullExport, timestamp, exportDirectory);
-    return new ResponseEntity<>(timestamp, HttpStatus.ACCEPTED);
+    UriComponents uriComponents = uriComponentsBuilder.path("/v1/export/{exportId}")
+            .buildAndExpand(timestamp);
+    HttpHeaders httpHeaders = new HttpHeaders();
+    httpHeaders.setLocation(uriComponents.toUri());
+    return new ResponseEntity<>(httpHeaders, HttpStatus.ACCEPTED);
   }
 
 


### PR DESCRIPTION
**What's in the PR**
* Send a Location header in response, containing the link to where the export can be downloaded instead of sending the exportId in response body

**How to test manually**
* Start an export and check if the described header exists
