### PR TITLE
#65 - Remove catch blocks from get element paths method

### DIFF
--- a/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
+++ b/src/main/java/de/dataelementhub/rest/controller/v1/ElementController.java
@@ -401,12 +401,8 @@ public class ElementController {
       List<List<SimplifiedElementIdentification>> elementPaths =
           elementService.getElementPaths(ctx, userId, urn, languages);
       return new ResponseEntity<>(elementPaths, HttpStatus.OK);
-    } catch (IllegalArgumentException e) {
-      return new ResponseEntity<>(e, HttpStatus.BAD_REQUEST);
-    } catch (IllegalStateException e) {
-      return new ResponseEntity<>(e.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
     } catch (NoSuchElementException nse) {
-      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+      return new ResponseEntity<>(nse.getMessage(), HttpStatus.NOT_FOUND);
     }
   }
 }


### PR DESCRIPTION
**What's in the PR**
* remove IllegalArgumentException and IllegalStateException catch block from get ElementController.getElementPaths
* add message to 404 not found error in ElementController.getElementPaths
* close #65 

**How to test manually**
* check if get element paths is still working
